### PR TITLE
Adding nightly IPA tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,14 +50,8 @@ jobs:
         - docker exec -it ${TASK} git clone ${GITHUB_REPO} /pki/
       script:
         # Generate SRPM
-        - >
-          docker exec -it ${TASK} 
-          /pki/build.sh 
-          --with-timestamp 
-          --with-commit-id 
-          --work-dir=/packages srpm
+        - travis_wait 15 ./buildCOPR.sh
         - docker exec -it ${TASK} ls /packages/SRPMS/
-        - docker exec -it ${TASK} bash -c 'copr-cli build ${COPR_REPO} /packages/SRPMS/*.src.rpm'
 
       after_script:
         # Clean the COPR repo for builds > 7 days
@@ -73,6 +67,7 @@ jobs:
         - COPR_REPO="@pki/${PKI_VERSION}-nightly"
         - HOST_RPMS=${TRAVIS_BUILD_DIR}/RPMS
         - BUILDER_RPMS=/tmp/RPMS
+        - LOGS=${TRAVIS_BUILD_DIR}/logs.txt
 
       before_install:
         - docker pull ${LOCAL_IMAGE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ cache: pip
 
 notifications:
   email:
-    - dmoluguw@redhat.com
-  on_success: always
+    - pki-team@redhat.com
+  on_success: change
   on_failure: always
 
 jobs:
   include:
-    # Nightly PKI COPR Build
-    - env:
+    - stage: PKI Nightly COPR Build
+      env:
         - TASK="pki-nightly"
         - IMAGE="registry.fedoraproject.org/fedora:28"
         - GITHUB_REPO="https://github.com/dogtagpki/pki.git"
@@ -39,7 +39,7 @@ jobs:
           ${IMAGE}
       
       install:
-        # Install git inside container
+        # Install required packages inside container
         - docker exec -it ${TASK} dnf install -y git dnf-plugins-core rpm-build copr-cli
         - docker exec -it ${TASK} dnf copr enable -y @pki/${PKI_VERSION}
         - docker exec -it ${TASK} dnf -y update
@@ -63,3 +63,60 @@ jobs:
         # Clean the COPR repo for builds > 7 days
         - docker exec -it ${TASK} /tmp/pki-copr-cleaner.py
 
+    - stage: IPA Nightly Test
+      env:
+        - TASK="ipatest-f27"
+        - LOCAL_IMAGE="registry.fedoraproject.org/fedora:27"
+        - IMAGE=f27_106_46
+        - GITHUB_REPO="https://github.com/dogtagpki/pki.git"
+        - PKI_VERSION=10.6
+        - COPR_REPO="@pki/${PKI_VERSION}-nightly"
+        - HOST_RPMS=${TRAVIS_BUILD_DIR}/RPMS
+        - BUILDER_RPMS=/tmp/RPMS
+
+      before_install:
+        - docker pull ${LOCAL_IMAGE}
+        - >
+          docker run
+          --detach
+          --name=${TASK}
+          --privileged
+          -e TRAVIS=${TRAVIS}
+          -e TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
+          -ti
+          ${LOCAL_IMAGE}
+
+      install:
+        # Install git inside container
+        - docker exec -it ${TASK} dnf install -y git dnf-plugins-core
+        # To install dependent packages like tomcatjss
+        - docker exec -it ${TASK} dnf copr enable -y @pki/${PKI_VERSION}
+        - docker exec -it ${TASK} dnf copr enable -y ${COPR_REPO}
+        - docker exec -it ${TASK} dnf -y update
+
+      before_script:
+        # Download the latest RPMs inside container from COPR
+        - docker exec -it ${TASK} mkdir -p ${BUILDER_RPMS}
+        - docker exec -it ${TASK} dnf install -y --downloadonly --downloaddir ${BUILDER_RPMS} pki      
+        
+        # Copy the RPMs to the host machine (to Travis machine)
+        - mkdir -p ${HOST_RPMS}
+        - docker cp ${TASK}:${BUILDER_RPMS}/. ${HOST_RPMS}
+
+        # Clone upstream PKI repo from github
+        - git clone ${GITHUB_REPO} ${TRAVIS_BUILD_DIR}/pki
+
+        # Install ipa-docker-test-runner tool
+        - pyenv global system 3.6
+        - pip3 install --upgrade pip # This will be removed in future
+        # This will be removed in future once ipa-init.sh is cleaned -- removing `mkdir` & `docker cp` commands
+        - pip3 install git+https://github.com/freeipa/ipa-docker-test-runner@release-0-3-1
+        
+
+      script:
+        # Run the IPA tests
+        - cd ${TRAVIS_BUILD_DIR}/pki && travis/ipa-test.sh
+
+      after_script:
+        - docker kill ${TASK}
+        - docker rm ${TASK}

--- a/buildCOPR.sh
+++ b/buildCOPR.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Build src rpm from cloned repo
+docker exec -i ${TASK} \
+    /pki/build.sh \
+    --with-timestamp \
+    --with-commit-id \
+    --work-dir=/packages srpm
+
+# Build RPMs in COPR
+docker exec -i ${TASK} \
+    bash -c 'copr build $COPR_REPO /packages/SRPMS/*.src.rpm'


### PR DESCRIPTION
2 containers are being spawned (1 of them will be removed in future)
- 1st container downloads the PKI rpms from COPR
- ipa-docker-test-runner spawns a new container and installs \
	the latest PKI rpms -- the tool will be removed in future

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>