### PR TITLE
Updated global variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,13 +204,14 @@ jobs:
       before_install:  
         - git clone ${GITHUB_REPO}
         - set -a && source pki/travis/global_variables
+        - set -a && source global_variables
         - touch ${LOGS}
 
       install:
         - pki/travis/builder-init.sh
         - docker exec -it ${CONTAINER} dnf install -y dnf-plugins-core
         # Enable nightly COPR repo
-        - docker exec -it ${CONTAINER} dnf copr enable -y @pki/${PKI_VERSION}-nightly
+        - docker exec -it ${CONTAINER} dnf copr enable -y ${TEST_COPR_REPO}
         # Install latest IPA from official fedora/updates repo
         - docker exec -it ${CONTAINER} ${BUILDDIR}/pki/pki/travis/ipa-init.sh
 
@@ -231,13 +232,14 @@ jobs:
       before_install:  
         - git clone ${GITHUB_REPO}
         - set -a && source pki/travis/global_variables
+        - set -a && source global_variables
         - touch ${LOGS}
 
       install:
         - pki/travis/builder-init.sh
         - docker exec -it ${CONTAINER} dnf install -y dnf-plugins-core
         # Enable nightly COPR repo
-        - docker exec -it ${CONTAINER} dnf copr enable -y @pki/${PKI_VERSION}-nightly
+        - docker exec -it ${CONTAINER} dnf copr enable -y ${TEST_COPR_REPO}
         # Install latest IPA from official fedora/updates repo
         - docker exec -it ${CONTAINER} ${BUILDDIR}/pki/pki/travis/ipa-init.sh
 

--- a/buildCOPR.sh
+++ b/buildCOPR.sh
@@ -2,4 +2,4 @@
 
 # Build RPMs in COPR
 docker exec -i ${TASK} \
-   bash -c 'copr build $COPR_REPO ${DEST_PKG_DIR}/SRPMS/*.src.rpm'
+   bash -c 'copr build $TEST_COPR_REPO ${DEST_PKG_DIR}/SRPMS/*.src.rpm'

--- a/buildInit.sh
+++ b/buildInit.sh
@@ -11,7 +11,7 @@ docker run \
     -e BUILDUSER_UID=$(id -u) \
     -e BUILDUSER_GID=$(id -g) \
     -e COPR_API="${COPR_API}" \
-    -e COPR_REPO="${COPR_REPO}" \
+    -e TEST_COPR_REPO="${TEST_COPR_REPO}" \
     -e DEST_PKG_DIR="${DEST_PKG_DIR}" \
     -e TRAVIS=${TRAVIS} \
     -e TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER} \

--- a/buildInstall.sh
+++ b/buildInstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 docker exec -it ${TASK} dnf install -y git dnf-plugins-core rpm-build copr-cli
-docker exec -it ${TASK} dnf copr enable -y @pki/${PKI_VERSION}
+docker exec -it ${TASK} dnf copr enable -y ${COPR_REPO}
 docker exec -it ${TASK} dnf -y update

--- a/global_variables
+++ b/global_variables
@@ -1,5 +1,5 @@
 IMAGE="registry.fedoraproject.org/fedora:28"
-PKI_VERSION=10.6
-COPR_REPO="@pki/${PKI_VERSION}-nightly"
+COPR_REPO="@pki/10.6"
+TEST_COPR_REPO="${COPR_REPO}-nightly"
 GITHUB_REPO="https://github.com/dogtagpki/${TASK}.git"
 DEST_PKG_DIR="/tmp/packages"

--- a/setupCOPR.sh
+++ b/setupCOPR.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+if [ "$COPR_API" == "" ]; then
+    echo "ERROR: COPR_API environment variable undefined"
+    echo "NOTE: Travis won't inject Secure variables in Pull Request"
+    exit 1
+fi
+
 docker exec -it ${TASK} bash -c 'mkdir -p ~/.config/ && echo -e ${COPR_API} > ~/.config/copr'
 docker exec -it ${TASK} git clone ${GITHUB_REPO}


### PR DESCRIPTION
The COPR_REPO variable has been replaced with TEST_COPR_REPO to
prevent collision with pki's COPR_REPO variable. The PKI_VERSION
variable has been replaced with COPR_REPO to match pki project.

The setupCOPR.sh has been modified to validate that the COPR_API
environment variable is defined.