### PR TITLE
Remove metadata_lock.pid to avoid issue in F30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 
 install:
   - pki/travis/builder-init.sh
+  - docker exec -it ${CONTAINER} rm -rf /var/cache/dnf/metadata_lock.pid
   - docker exec -it ${CONTAINER} dnf install -y dnf-plugins-core
   # Enable automated COPR repo
   - docker exec -it ${CONTAINER} dnf copr enable -y ${COPR_REPO}


### PR DESCRIPTION
Fixes the "[Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'"
when trying to install the `dnf-plugins-core`

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`